### PR TITLE
docs(README): remove mention of import resolver

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,17 +5,6 @@
     "sourceType": "module",
     "project": "./tsconfig.json"
   },
-  "settings": {
-    "import/parsers": {
-      "@typescript-eslint/parser": [".ts", ".tsx"]
-    },
-    "import/resolver": {
-      "typescript": {
-        "alwaysTryTypes": true,
-        "directory": "./tsconfig.json"
-      }
-    }
-  },
   // "plugins": ["@typescript-eslint", "deprecation"],
   "rules": {
     // "deprecation/deprecation": "warn"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Which means that you should install dev deps:
 - `@typescript-eslint/parser`
 - `typescript`
 
-Then configure your `.eslintrc` like this:
+Then configure ESLint to parse TypeScript and include type information:
 
 ```jsonc
 {
@@ -28,17 +28,6 @@ Then configure your `.eslintrc` like this:
     "ecmaVersion": 2020,
     "sourceType": "module",
     "project": "./tsconfig.json" // <-- Point to your project's tsconfig.json or create new one
-  },
-  "settings": {
-    "import/parsers": {
-      "@typescript-eslint/parser": [".ts", ".tsx"]
-    },
-    "import/resolver": {
-      "typescript": {
-        "alwaysTryTypes": true,
-        "directory": "./tsconfig.json" // <-- Same tsconfig.json must be referenced
-      }
-    }
   }
 }
 ```


### PR DESCRIPTION
I just tried using the latest version of this plugin and this configuration was not necessary, it actually caused issues with how I was already using eslint-plugin-import. I don't see how it's relevant to this package, so I've removed that mention from the README. Let me know if I should also remove this bit of config from this project's own ESLint config.