### PR TITLE
Allow `typescript@^4` as peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "peerDependencies": {
     "eslint": "^6.0.0 || ^7.0.0",
-    "typescript": "^3.7.5 || ^4"
+    "typescript": "^3.7.5 || ^4.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.3.5",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "peerDependencies": {
     "eslint": "^6.0.0 || ^7.0.0",
-    "typescript": "^3.7.5"
+    "typescript": "^3.7.5 || ^4"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.3.5",


### PR DESCRIPTION
Fixes #11 