### PR TITLE
[Fix] Handle array-based tag.text

### DIFF
--- a/src/rules/deprecation.ts
+++ b/src/rules/deprecation.ts
@@ -289,7 +289,11 @@ function isCallExpression(
 function getJsDocDeprecation(tags: ts.JSDocTagInfo[]) {
   for (const tag of tags) {
     if (tag.name === 'deprecated') {
-      return { reason: tag.text || '' };
+      let reason = tag.text;
+      if (Array.isArray(reason)) {
+        reason = reason.map(val => val.text).join('');
+      }
+      return { reason: reason || '' };
     }
   }
   return undefined;


### PR DESCRIPTION
This fixes #29, though I'm not really familiar with most of this functionality, so it may not be the most optimal/ideal solution.

Particularly, metadata for eg. links is not handled very gracefully, eg:
```
163:28  warning  'click' is deprecated. Deprecated since 3.3. Use \`{@link on}\` or \`{@link trigger}\`.
```