### PR TITLE
fix: print deprecation reason correctly on ts 4.3+

### DIFF
--- a/src/rules/deprecation.ts
+++ b/src/rules/deprecation.ts
@@ -20,6 +20,7 @@ import {
 } from '@typescript-eslint/experimental-utils';
 import { isReassignmentTarget } from 'tsutils';
 import * as ts from 'typescript';
+import { stringifyJSDocTagInfoText } from '../utils/stringifyJSDocTagInfoText';
 
 const createRule = ESLintUtils.RuleCreator(
   () => 'https://github.com/gund/eslint-plugin-deprecation',
@@ -288,7 +289,7 @@ function isCallExpression(
 function getJsDocDeprecation(tags: ts.JSDocTagInfo[]) {
   for (const tag of tags) {
     if (tag.name === 'deprecated') {
-      return { reason: tag.text || '' };
+      return { reason: stringifyJSDocTagInfoText(tag) };
     }
   }
   return undefined;

--- a/src/utils/stringifyJSDocTagInfoText.ts
+++ b/src/utils/stringifyJSDocTagInfoText.ts
@@ -1,0 +1,28 @@
+import * as ts from 'typescript';
+
+/**
+ * Stringifies the text within a JSDocTagInfo AST node with compatibility for
+ * pre/post TypeScript 4.3 API changes.
+ */
+export function stringifyJSDocTagInfoText(tag: ts.JSDocTagInfo): string {
+  return isJSDocTagInfo4Point2AndBefore(tag)
+    ? tag.text ?? ''
+    : ts.displayPartsToString(tag.text);
+}
+
+/**
+ * Copied from TypeScript 4.2.
+ * https://github.com/microsoft/TypeScript/blob/fb6c8392681f50a305236a7d662123a69827061f/lib/protocol.d.ts#L2820-L2823
+ *
+ * The `text` field was changed from `string` to `SymbolDisplayPart[]` in 4.3.
+ */
+interface JSDocTagInfo4Point2AndBefore {
+  name: string;
+  text?: string;
+}
+
+function isJSDocTagInfo4Point2AndBefore(
+  tag: ts.JSDocTagInfo | JSDocTagInfo4Point2AndBefore,
+): tag is JSDocTagInfo4Point2AndBefore {
+  return typeof tag.text === 'string';
+}


### PR DESCRIPTION
This is an alternative to https://github.com/gund/eslint-plugin-deprecation/pull/33 that uses the builtin [`ts.displayPartsToString` function](https://github.com/microsoft/TypeScript/blob/586b0d5011350d1c373517a83cf7720e2c864962/src/services/services.ts#L925) and passes the `codeclimate` status check.

I'd bias towards merging https://github.com/gund/eslint-plugin-deprecation/pull/33 if reviewers are on the fence. This PR was created before I realized that existed.