### PR TITLE
Update TravisCI to newer distro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: focal
 language: node_js
 notifications:
   email: false


### PR DESCRIPTION
As new nodejs 18 requires newer OS dependencies (see https://travis-ci.community/t/the-command-npm-config-set-spin-false-failed-and-exited-with-1-during/12909/6).