### PR TITLE
Add typescript v5 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "peerDependencies": {
     "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0",
-    "typescript": "^3.7.5 || ^4.0.0 || ^5.0.0"
+    "typescript": "^3.7.5 || ^4.0.0 || ^5.0.0 || ^5.0.0-beta"
   },
   "devDependencies": {
     "@commitlint/cli": "^13.2.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "peerDependencies": {
     "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0",
-    "typescript": "^3.7.5 || ^4.0.0"
+    "typescript": "^3.7.5 || ^4.0.0 || ^5.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^13.2.1",


### PR DESCRIPTION
It works good. It will not require to use `--force` flag to install this plugin if you use **typescript@5**.