### PR TITLE
fix(deps): use `@typescript-eslint/utils` instead of experimental

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-development",
       "license": "LGPL-3.0-or-later",
       "dependencies": {
-        "@typescript-eslint/experimental-utils": "^5.57.0",
+        "@typescript-eslint/utils": "^5.57.0",
         "tslib": "^2.3.1",
         "tsutils": "^3.21.0"
       },
@@ -2304,24 +2304,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@typescript-eslint/experimental-utils": {
-      "version": "5.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.57.0.tgz",
-      "integrity": "sha512-0RnrwGQ7MmgtOSnzB/rSGYr2iXENi6L+CtPzX3g5ovo0HlruLukSEKcc4s+q0IEc+DLTDc7Edan0Y4WSQ/bFhw==",
-      "dependencies": {
-        "@typescript-eslint/utils": "5.57.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
@@ -14220,14 +14202,6 @@
         "natural-compare-lite": "^1.4.0",
         "semver": "^7.3.7",
         "tsutils": "^3.21.0"
-      }
-    },
-    "@typescript-eslint/experimental-utils": {
-      "version": "5.57.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.57.0.tgz",
-      "integrity": "sha512-0RnrwGQ7MmgtOSnzB/rSGYr2iXENi6L+CtPzX3g5ovo0HlruLukSEKcc4s+q0IEc+DLTDc7Edan0Y4WSQ/bFhw==",
-      "requires": {
-        "@typescript-eslint/utils": "5.57.0"
       }
     },
     "@typescript-eslint/parser": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "semantic-release": "semantic-release"
   },
   "dependencies": {
-    "@typescript-eslint/experimental-utils": "^5.57.0",
+    "@typescript-eslint/utils": "^5.57.0",
     "tslib": "^2.3.1",
     "tsutils": "^3.21.0"
   },

--- a/src/rules/deprecation.ts
+++ b/src/rules/deprecation.ts
@@ -13,11 +13,7 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-import {
-  ESLintUtils,
-  TSESLint,
-  TSESTree,
-} from '@typescript-eslint/experimental-utils';
+import { ESLintUtils, TSESLint, TSESTree } from '@typescript-eslint/utils';
 import { isReassignmentTarget } from 'tsutils';
 import * as ts from 'typescript';
 import { stringifyJSDocTagInfoText } from '../utils/stringifyJSDocTagInfoText';

--- a/tests/rules/deprecation.test.ts
+++ b/tests/rules/deprecation.test.ts
@@ -1,4 +1,4 @@
-import { TSESLint, ESLintUtils } from '@typescript-eslint/experimental-utils';
+import { TSESLint, ESLintUtils } from '@typescript-eslint/utils';
 import rule, { MessageIds, Options } from '../../src/rules/deprecation';
 import * as path from 'path';
 
@@ -181,10 +181,10 @@ ruleTester.run('deprecation', rule, {
     const obj = new Class();
     obj.method('');
   `),
-  // Method overloads in interfaces extending a class
-  // This notation used to be mentioned in the TypeScript handbook
-  // See https://www.typescriptlang.org/docs/handbook/classes.html#using-a-class-as-an-interface
-  getValidTestCase(`
+    // Method overloads in interfaces extending a class
+    // This notation used to be mentioned in the TypeScript handbook
+    // See https://www.typescriptlang.org/docs/handbook/classes.html#using-a-class-as-an-interface
+    getValidTestCase(`
     class Class {}
     interface Interface extends Class {
       method(param: string): void;


### PR DESCRIPTION
Addresses https://github.com/gund/eslint-plugin-deprecation/pull/63#discussion_r1157924605