### PR TITLE
Add "deprecation" docs with screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ Reports usage of anything marked with a `@deprecated` JSDoc tag (browser APIs, N
 
 **Deprecated browser APIs**
 
-<img width="620" src="https://github.com/gund/eslint-plugin-deprecation/assets/1935696/361d6546-aa74-4b32-b977-36b6e3f183fa" alt="Screenshot of warning `'event' is deprecated` raised by eslint-plugin-deprecation" />
+<img width="620" src="https://github.com/gund/eslint-plugin-deprecation/assets/1935696/361d6546-aa74-4b32-b977-36b6e3f183fa" alt="Screenshot of warning `'event' is deprecated` raised by eslint-plugin-deprecation" /><br />
 
 **Deprecated Node.js APIs**
 
-<img width="620" src="https://github.com/gund/eslint-plugin-deprecation/assets/1935696/ad0fa944-5c0a-4cc0-84a4-f1a94ba6c631" alt="Screenshot of warning `'parse' is deprecated. Use the WHATWG URL API instead.` raised by eslint-plugin-deprecation" />
+<img width="620" src="https://github.com/gund/eslint-plugin-deprecation/assets/1935696/ad0fa944-5c0a-4cc0-84a4-f1a94ba6c631" alt="Screenshot of warning `'parse' is deprecated. Use the WHATWG URL API instead.` raised by eslint-plugin-deprecation" /><br />
 
 **Deprecated library APIs**
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 > An [ESLint](https://eslint.org/) rule that reports usage of deprecated code.
 
-Reports usage of any code marked with a `@deprecated` JSDoc tag (incl. browser APIs, Node.js APIs, library APIs, etc.)
+Reports usage of any code marked with a [`@deprecated` JSDoc tag](https://jsdoc.app/tags-deprecated.html) (incl. browser APIs, Node.js APIs, library APIs, etc.)
 
 **Deprecated browser APIs**
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 > An [ESLint](https://eslint.org/) rule that reports usage of deprecated code.
 
-Shows usage of anything marked with the `@deprecated` JSDoc tag (browser APIs, Node.js APIs, library APIs, etc)
+Reports usage of anything marked with a `@deprecated` JSDoc tag (browser APIs, Node.js APIs, library APIs, etc)
 
 **Deprecated browser APIs**
 

--- a/README.md
+++ b/README.md
@@ -15,15 +15,15 @@ Reports usage of anything marked with a `@deprecated` JSDoc tag (browser APIs, N
 
 **Deprecated browser APIs**
 
-<img src="https://github.com/gund/eslint-plugin-deprecation/assets/1935696/361d6546-aa74-4b32-b977-36b6e3f183fa" alt="Screenshot of warning `'event' is deprecated` raised by eslint-plugin-deprecation" />
+<img width="620" src="https://github.com/gund/eslint-plugin-deprecation/assets/1935696/361d6546-aa74-4b32-b977-36b6e3f183fa" alt="Screenshot of warning `'event' is deprecated` raised by eslint-plugin-deprecation" />
 
 **Deprecated Node.js APIs**
 
-<img src="https://github.com/gund/eslint-plugin-deprecation/assets/1935696/ad0fa944-5c0a-4cc0-84a4-f1a94ba6c631" alt="Screenshot of warning `'parse' is deprecated. Use the WHATWG URL API instead.` raised by eslint-plugin-deprecation" />
+<img width="620" src="https://github.com/gund/eslint-plugin-deprecation/assets/1935696/ad0fa944-5c0a-4cc0-84a4-f1a94ba6c631" alt="Screenshot of warning `'parse' is deprecated. Use the WHATWG URL API instead.` raised by eslint-plugin-deprecation" />
 
 **Deprecated library APIs**
 
-<img src="https://github.com/gund/eslint-plugin-deprecation/assets/1935696/a26d41be-0069-476f-9c6a-9f930edafeb1" alt="Screenshot of warning `'cheerio' is deprecated. Use the function returned by `load` instead` raised by eslint-plugin-deprecation" />
+<img width="620" src="https://github.com/gund/eslint-plugin-deprecation/assets/1935696/a26d41be-0069-476f-9c6a-9f930edafeb1" alt="Screenshot of warning `'cheerio' is deprecated. Use the function returned by `load` instead` raised by eslint-plugin-deprecation" />
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ If you don't want to use the `recommended` config for some reason, you can accom
 
 ### Disallow usage of deprecated APIs (`deprecation`)
 
-Reports usage of any code marked with a [`@deprecated` JSDoc tag](https://jsdoc.app/tags-deprecated.html), including browser APIs, Node.js APIs, library APIs, etc.
+Reports usage of any code marked with a [`@deprecated` JSDoc tag](https://jsdoc.app/tags-deprecated.html). For example, this includes browser APIs, Node.js APIs, library APIs and any other code that is marked with this tag.
 
 #### Rule Details
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,20 @@
 
 > An [ESLint](https://eslint.org/) rule that reports usage of deprecated code.
 
+Shows usage of anything marked with the `@deprecated` JSDoc tag (browser APIs, Node.js APIs, library APIs, etc)
+
+**Deprecated browser APIs**
+
+<img src="https://github.com/gund/eslint-plugin-deprecation/assets/1935696/361d6546-aa74-4b32-b977-36b6e3f183fa" alt="Screenshot of warning `'event' is deprecated` raised by eslint-plugin-deprecation" />
+
+**Deprecated Node.js APIs**
+
+<img src="https://github.com/gund/eslint-plugin-deprecation/assets/1935696/ad0fa944-5c0a-4cc0-84a4-f1a94ba6c631" alt="Screenshot of warning `'parse' is deprecated. Use the WHATWG URL API instead.` raised by eslint-plugin-deprecation" />
+
+**Deprecated library APIs**
+
+<img src="https://github.com/gund/eslint-plugin-deprecation/assets/1935696/a26d41be-0069-476f-9c6a-9f930edafeb1" alt="Screenshot of warning `'cheerio' is deprecated. Use the function returned by `load` instead` raised by eslint-plugin-deprecation" />
+
 ## Prerequisites
 
 If you already use [TypeScript](https://www.typescriptlang.org/) and one or more rules from the [`typescript-eslint`](https://typescript-eslint.io/) plugin, then `eslint-plugin-deprecation` will work out of the box without any additional dependencies or special configuration specified in this section. (This is because `@typescript-eslint/plugin` automatically contains `@typescript-eslint/parser` and your ESLint should already be configured with the `parserOptions` to work properly with TypeScript.)

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ If you don't want to use the `recommended` config for some reason, you can accom
 
 ### Disallow usage of deprecated APIs (`deprecation`)
 
-Reports usage of any code marked with a [`@deprecated` JSDoc tag](https://jsdoc.app/tags-deprecated.html) (incl. browser APIs, Node.js APIs, library APIs, etc.)
+Reports usage of any code marked with a [`@deprecated` JSDoc tag](https://jsdoc.app/tags-deprecated.html), including browser APIs, Node.js APIs, library APIs, etc.
 
 #### Rule Details
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 > An [ESLint](https://eslint.org/) rule that reports usage of deprecated code.
 
-Reports usage of anything marked with a `@deprecated` JSDoc tag (browser APIs, Node.js APIs, library APIs, etc)
+Reports usage of any code marked with a `@deprecated` JSDoc tag (incl. browser APIs, Node.js APIs, library APIs, etc.)
 
 **Deprecated browser APIs**
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,9 @@ If you don't want to use the `recommended` config for some reason, you can accom
 
 ### Disallow usage of deprecated APIs (`deprecation/deprecation`)
 
-Reports usage of any code marked with a [`@deprecated` JSDoc tag](https://jsdoc.app/tags-deprecated.html). For example, this includes browser APIs, Node.js APIs, library APIs and any other code that is marked with this tag.
+Reports usage of any code marked with a [`@deprecated` JSDoc tag](https://jsdoc.app/tags-deprecated.html).
+
+For example, this includes browser APIs, Node.js APIs, library APIs and any other code that is marked with this tag.
 
 #### Rule Details
 

--- a/README.md
+++ b/README.md
@@ -9,21 +9,7 @@
 [![License](https://img.shields.io/npm/l/eslint-plugin-deprecation.svg?maxAge=2592000)](https://github.com/gund/eslint-plugin-deprecation/blob/master/LICENSE)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
-> An [ESLint](https://eslint.org/) rule that reports usage of deprecated code.
-
-Reports usage of any code marked with a [`@deprecated` JSDoc tag](https://jsdoc.app/tags-deprecated.html) (incl. browser APIs, Node.js APIs, library APIs, etc.)
-
-**Deprecated browser APIs**
-
-<img width="620" src="https://github.com/gund/eslint-plugin-deprecation/assets/1935696/361d6546-aa74-4b32-b977-36b6e3f183fa" alt="Screenshot of warning `'event' is deprecated` raised by eslint-plugin-deprecation" /><br />
-
-**Deprecated Node.js APIs**
-
-<img width="620" src="https://github.com/gund/eslint-plugin-deprecation/assets/1935696/ad0fa944-5c0a-4cc0-84a4-f1a94ba6c631" alt="Screenshot of warning `'parse' is deprecated. Use the WHATWG URL API instead.` raised by eslint-plugin-deprecation" /><br />
-
-**Deprecated library APIs**
-
-<img width="620" src="https://github.com/gund/eslint-plugin-deprecation/assets/1935696/a26d41be-0069-476f-9c6a-9f930edafeb1" alt="Screenshot of warning `'cheerio' is deprecated. Use the function returned by `load` instead` raised by eslint-plugin-deprecation" />
+> An [ESLint](https://eslint.org/) plugin with rules reporting usage of deprecated code
 
 ## Prerequisites
 
@@ -91,6 +77,48 @@ If you don't want to use the `recommended` config for some reason, you can accom
     "deprecation/deprecation": "error",
   },
 }
+```
+
+## Rules
+
+### Disallow usage of deprecated APIs (`deprecation`)
+
+Reports usage of any code marked with a [`@deprecated` JSDoc tag](https://jsdoc.app/tags-deprecated.html) (incl. browser APIs, Node.js APIs, library APIs, etc.)
+
+#### Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```ts
+import { parse } from 'node:url';
+import cheerio from 'cheerio';
+
+// Node.js API
+const url = parse('/foo'); // ❌ 'parse' is deprecated. Use the WHATWG URL API instead. eslint(deprecation/deprecation)
+
+// Browser API
+console.log(event?.bubbles); // ❌ 'event' is deprecated. [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/event) eslint(deprecation/deprecation)
+
+// Deprecated library API
+cheerio('<h2 class="title">Hello world</h2>'); // ❌ 'cheerio' is deprecated. Use the function returned by `load` instead. eslint(deprecation/deprecation)
+```
+
+Examples of **correct** code for this rule:
+
+```ts
+import { load } from 'cheerio';
+import { ChangeEvent } from 'react';
+
+// Node.js API
+const url2 = new URL('/foo', 'http://www.example.com'); // ✅ Modern Node.js API, uses `new URL()`
+
+// Browser API
+function onClick(event: ChangeEvent<HTMLInputElement>) {
+  console.log(event.bubbles); // ✅ Modern browser API, does not use global
+}
+
+// Library API
+load('<h2 class="title">Hello world</h2>'); // ✅ Allowed library API, uses named `load` import
 ```
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ If you don't want to use the `recommended` config for some reason, you can accom
 
 ## Rules
 
-### Disallow usage of deprecated APIs (`deprecation`)
+### Disallow usage of deprecated APIs (`deprecation/deprecation`)
 
 Reports usage of any code marked with a [`@deprecated` JSDoc tag](https://jsdoc.app/tags-deprecated.html). For example, this includes browser APIs, Node.js APIs, library APIs and any other code that is marked with this tag.
 


### PR DESCRIPTION
Closes #72

Keeps the wording very short, but gives a bunch of examples with code blocks:

![Screenshot 2023-10-15 at 13 10 09](https://github.com/gund/eslint-plugin-deprecation/assets/1935696/447515fb-884b-463c-8df2-b7de417058ff)

